### PR TITLE
Refactor payment method content component

### DIFF
--- a/assets/js/allcomet-gateway-blocks.js
+++ b/assets/js/allcomet-gateway-blocks.js
@@ -163,21 +163,20 @@
         );
     };
 
-    const render = (props) => {
-        return createElement(
+    const PaymentMethodContent = (props) =>
+        createElement(
             Fragment,
             {},
             description ? createElement('p', { className: 'wc-block-allcomet-description' }, description) : null,
             createElement(PaymentFields, props)
         );
-    };
 
     registerPaymentMethod({
         name: 'allcomet',
         label,
         ariaLabel: label,
-        content: render,
-        edit: render,
+        content: createElement(PaymentMethodContent),
+        edit: createElement(PaymentMethodContent),
         canMakePayment: () => true,
         supports: {
             features: settings.supports || ['products'],


### PR DESCRIPTION
## Summary
- replace the `render` helper with a `PaymentMethodContent` component that returns the payment fields
- provide React elements for the `content` and `edit` properties when registering the payment method

## Testing
- not run (requires WooCommerce Blocks environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfe672e6dc83329f2e4c28f4205944