### PR TITLE
Wrap Blocks payment data under meta

### DIFF
--- a/assets/js/allcomet-gateway-blocks.js
+++ b/assets/js/allcomet-gateway-blocks.js
@@ -117,13 +117,16 @@
                     };
                 }
 
+                // The Blocks API expects additional payment data under a meta key.
                 return {
                     type: responseTypes.SUCCESS,
-                    paymentMethodData: {
-                        allcomet_card_number: cardNumber,
-                        allcomet_expiry_month: expiryMonth,
-                        allcomet_expiry_year: expiryYear,
-                        allcomet_card_cvc: cvc,
+                    meta: {
+                        paymentMethodData: {
+                            allcomet_card_number: cardNumber,
+                            allcomet_expiry_month: expiryMonth,
+                            allcomet_expiry_year: expiryYear,
+                            allcomet_card_cvc: cvc,
+                        },
                     },
                 };
             });


### PR DESCRIPTION
## Summary
- update the AllComet Blocks payment fields success response to return data under `meta.paymentMethodData`
- add an inline comment explaining the `meta` usage for the Blocks API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2534ad3f88332896b34e5c0735bd7