### PR TITLE
Add flex styling for expiry fields in Blocks checkout

### DIFF
--- a/assets/js/allcomet-gateway-blocks.js
+++ b/assets/js/allcomet-gateway-blocks.js
@@ -90,6 +90,29 @@
         const [cvc, setCvc] = useState('');
 
         useEffect(() => {
+            // Ensure the checkout specific styling for the expiry fields is only added once.
+            if (typeof document !== 'undefined' && ! document.getElementById('allcomet-block-styles')) {
+                const checkoutContainer = document.querySelector('.wc-block-checkout');
+
+                if (checkoutContainer) {
+                    const style = document.createElement('style');
+                    style.id = 'allcomet-block-styles';
+                    style.textContent = `
+                        .wc-block-checkout .wc-block-components-field-group.allcomet-expiry-group {
+                            display: flex;
+                            gap: 1rem;
+                            flex-wrap: wrap;
+                        }
+
+                        .wc-block-checkout .wc-block-components-field-group.allcomet-expiry-group > .wc-block-components-field {
+                            flex: 1 1 0;
+                        }
+                    `;
+
+                    checkoutContainer.appendChild(style);
+                }
+            }
+
             const unsubscribe = eventRegistration.onPaymentProcessing(() => {
                 const errors = [];
 


### PR DESCRIPTION
## Summary
- inject a stylesheet for the AllComet expiry field group when the Blocks checkout renders
- ensure the flex-based layout only targets the checkout block and is added once

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e265a4ba608332a136d2116cc3623b