### PR TITLE
Add card holder field handling for AllComet gateway

### DIFF
--- a/assets/js/allcomet-gateway-blocks.js
+++ b/assets/js/allcomet-gateway-blocks.js
@@ -14,6 +14,7 @@
 
     const errorMessages = Object.assign(
         {
+            cardHolder: __('Please enter the card holder name.', 'allcomet-woocommerce'),
             cardNumber: __('Please enter your card number.', 'allcomet-woocommerce'),
             expiryMonth: __('Please enter the card expiry month.', 'allcomet-woocommerce'),
             expiryYear: __('Please enter the card expiry year.', 'allcomet-woocommerce'),
@@ -47,6 +48,8 @@
         switch (id) {
             case 'allcomet-card-number':
                 return 'cc-number';
+            case 'allcomet-card-holder':
+                return 'cc-name';
             case 'allcomet-expiry-month':
                 return 'cc-exp-month';
             case 'allcomet-expiry-year':
@@ -84,6 +87,7 @@
     const PaymentFields = (props) => {
         const { eventRegistration, emitResponse } = props;
         const responseTypes = (emitResponse && emitResponse.responseTypes) ? emitResponse.responseTypes : { ERROR: 'ERROR', SUCCESS: 'SUCCESS' };
+        const [cardHolder, setCardHolder] = useState('');
         const [cardNumber, setCardNumber] = useState('');
         const [expiryMonth, setExpiryMonth] = useState('');
         const [expiryYear, setExpiryYear] = useState('');
@@ -116,6 +120,9 @@
             const unsubscribe = eventRegistration.onPaymentProcessing(() => {
                 const errors = [];
 
+                if (! cardHolder) {
+                    errors.push(errorMessages.cardHolder);
+                }
                 if (! cardNumber) {
                     errors.push(errorMessages.cardNumber);
                 }
@@ -145,6 +152,7 @@
                     type: responseTypes.SUCCESS,
                     meta: {
                         paymentMethodData: {
+                            allcomet_card_holder: cardHolder,
                             allcomet_card_number: cardNumber,
                             allcomet_expiry_month: expiryMonth,
                             allcomet_expiry_year: expiryYear,
@@ -159,11 +167,18 @@
                     unsubscribe();
                 }
             };
-        }, [cardNumber, expiryMonth, expiryYear, cvc, eventRegistration, emitResponse]);
+        }, [cardHolder, cardNumber, expiryMonth, expiryYear, cvc, eventRegistration, emitResponse]);
 
         return createElement(
             Fragment,
             {},
+            Field({
+                id: 'allcomet-card-holder',
+                labelText: __('Card holder name', 'allcomet-woocommerce'),
+                value: cardHolder,
+                onChange: setCardHolder,
+                placeholder: __('Jane Doe', 'allcomet-woocommerce'),
+            }),
             Field({
                 id: 'allcomet-card-number',
                 labelText: __('Card number', 'allcomet-woocommerce'),

--- a/includes/class-wc-gateway-allcomet-blocks.php
+++ b/includes/class-wc-gateway-allcomet-blocks.php
@@ -89,6 +89,7 @@ class WC_Gateway_Allcomet_Blocks extends AbstractPaymentMethodType
             'description' => $this->get_setting('description'),
             'supports'    => ['products'],
             'i18n'        => [
+                'cardHolder'  => __('Please enter the card holder name.', 'allcomet-woocommerce'),
                 'cardNumber'  => __('Please enter your card number.', 'allcomet-woocommerce'),
                 'expiryMonth' => __('Please enter the card expiry month.', 'allcomet-woocommerce'),
                 'expiryYear'  => __('Please enter the card expiry year.', 'allcomet-woocommerce'),

--- a/includes/class-wc-gateway-allcomet.php
+++ b/includes/class-wc-gateway-allcomet.php
@@ -133,12 +133,19 @@ class WC_Gateway_Allcomet extends WC_Payment_Gateway
             echo wpautop(wp_kses_post($this->description));
         }
 
+        $posted_holder  = isset($_POST['allcomet_card_holder']) ? wp_unslash($_POST['allcomet_card_holder']) : '';
         $posted_card    = isset($_POST['allcomet_card_number']) ? wp_unslash($_POST['allcomet_card_number']) : '';
         $posted_month   = isset($_POST['allcomet_expiry_month']) ? wp_unslash($_POST['allcomet_expiry_month']) : '';
         $posted_year    = isset($_POST['allcomet_expiry_year']) ? wp_unslash($_POST['allcomet_expiry_year']) : '';
         $posted_cvc     = isset($_POST['allcomet_card_cvc']) ? wp_unslash($_POST['allcomet_card_cvc']) : '';
 
         echo '<fieldset id="wc-allcomet-cc-form" class="wc-credit-card-form wc-payment-form">';
+        // Persist the card holder for both classic checkout and Blocks submissions.
+        echo '<p class="form-row form-row-wide">';
+        echo '<label for="allcomet_card_holder">' . esc_html__('Card holder name', 'allcomet-woocommerce') . ' <span class="required">*</span></label>';
+        echo '<input id="allcomet_card_holder" name="allcomet_card_holder" type="text" autocomplete="cc-name" placeholder="' . esc_attr__('Jane Doe', 'allcomet-woocommerce') . '" value="' . esc_attr($posted_holder) . '" />';
+        echo '</p>';
+
         echo '<p class="form-row form-row-wide">';
         echo '<label for="allcomet_card_number">' . esc_html__('Card number', 'allcomet-woocommerce') . ' <span class="required">*</span></label>';
         echo '<input id="allcomet_card_number" name="allcomet_card_number" type="text" autocomplete="cc-number" placeholder="•••• •••• •••• ••••" value="' . esc_attr($posted_card) . '" />';
@@ -171,6 +178,7 @@ class WC_Gateway_Allcomet extends WC_Payment_Gateway
         $this->log_checkout_snapshot('Validation snapshot');
 
         $required_fields = [
+            'allcomet_card_holder'   => __('Please enter the card holder name.', 'allcomet-woocommerce'),
             'allcomet_card_number'   => __('Please enter your card number.', 'allcomet-woocommerce'),
             'allcomet_expiry_month'  => __('Please enter the card expiry month.', 'allcomet-woocommerce'),
             'allcomet_expiry_year'   => __('Please enter the card expiry year.', 'allcomet-woocommerce'),


### PR DESCRIPTION
## Summary
- add a required card holder field and pass the value through Blocks payment data
- expose the localized card holder validation message to the Blocks script
- capture, persist, and validate the card holder field in the classic checkout form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e267b7cc2c83328ffda5a249749523